### PR TITLE
Circumvent the LGTM-Python check triggering

### DIFF
--- a/tools/json_tools/util.py
+++ b/tools/json_tools/util.py
@@ -362,10 +362,7 @@ class CDDAJSONWriter(object):
                 self.indent_multiplier -= 1
             self.buf.write("\n")
             self.indented_write("]")
-            if lol:
-                self.buf.write(",\n")
-            else:
-                self.buf.write("\n")
+            self.buf.write(",\n" if lol else "\n")
             self.indent_multiplier -= 1
         self.indented_write("]")
 


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

This can circumvent the LGTM check (Unreachable statement) triggering.
And save 3 LOC.

#### Describe the solution

Rewrite block with list's emptiness check.

#### Describe alternatives you've considered

Wait for the nextgen LGTM.

#### Testing

CI should do it.
(Not here I guess.)